### PR TITLE
Downgrade ollama to 0.1.17

### DIFF
--- a/packages/ollama.nix
+++ b/packages/ollama.nix
@@ -5,7 +5,7 @@
   autoPatchelfHook,
 }: let
   pname = "ollama";
-  version = "0.1.18";
+  version = "0.1.17";
   repo = "https://github.com/jmorganca/ollama";
   url = "${repo}/releases/download/v${version}/${pname}-linux-amd64";
 in
@@ -14,7 +14,7 @@ in
 
     src = fetchurl {
       inherit url;
-      hash = "sha256-bEtjSCl520uvJhPuhsl4eSDAr8th3zm0n1YJxL/mTXc=";
+      hash = "sha256-t33uwWlqVJC7lCN4n/4nRxPG1ipnGc31Cxr9lR4jxws=";
     };
 
     nativeBuildInputs = lib.optional stdenv.isLinux autoPatchelfHook;


### PR DESCRIPTION
When running the current version, the build fails due to missing dependencies:
```
/nix/store/s7wp33p88k2icbxaw95vy2kpjg7r6r5w-ollama-0.1.18/bin/ollama searching for dependencies of /nix/store/s7wp33p88k2icbxaw95vy2kpjg7r6r5w-ollama-0.1.18/bin/ollama
    libstdc++.so.6 -> not found! libgcc_s.so.1 -> not found! auto-patchelf: 2 dependencies could not be satisfied error: auto-patchelf could not satisfy dependency libstdc++.so.6 wanted
by /nix/store/s7wp33p88k2icbxaw95vy2kpjg7r6r5w-ollama-0.1.18/bin/ollama error: auto-patchelf could not satisfy dependency libgcc_s.so.1 wanted by
/nix/store/s7wp33p88k2icbxaw95vy2kpjg7r6r5w-ollama-0.1.18/bin/ollama auto-patchelf failed to find all the required dependencies. Add the missing dependencies to --libs or use
`--ignore-missing="foo.so.1 bar.so etc.so"`. /nix/store/d4jf1cbbk494zwgbqz31pxgigpsbh6w2-stdenv-linux/setup: line 74: pop_var_context: head of shell_variables not a function context
/nix/store/d4jf1cbbk494zwgbqz31pxgigpsbh6w2-stdenv-linux/setup: line 1450: pop_var_context: head of shell_variables not a function context
/nix/store/d4jf1cbbk494zwgbqz31pxgigpsbh6w2-stdenv-linux/setup: line 1553: pop_var_context: head of shell_variables not a function context
```

Downgrading ollama to 0.1.17 fixes this issue.